### PR TITLE
Predecessor patch

### DIFF
--- a/pytrack/matching/mpmatching.py
+++ b/pytrack/matching/mpmatching.py
@@ -79,6 +79,8 @@ def viterbi_search(G, trellis, start="start", target="target", beta=mpmatching_u
             except Exception as error:
                 print(error)
 
-    predecessor = mpmatching_utils.get_predecessor("target", predecessor)
+    # get_predecessor and viterbi_search should seperate. Decoupling!
+                     
+    #predecessor = mpmatching_utils.get_predecessor("target", predecessor)
 
     return joint_prob[target], predecessor

--- a/pytrack/matching/mpmatching_utils.py
+++ b/pytrack/matching/mpmatching_utils.py
@@ -187,10 +187,22 @@ def get_predecessor(target, predecessor):
     pred_elab: dict
         Dictionary containing the predecessors of the best nodes of a decoded Trellis DAG.
     """
+    
+    """
+    2023/02/03
+    
+    the key "target" may not be in the predecessor
+    check if key in the predecessor or not before the "get" occurs  
+    """
+    
     pred_elab = {}
+    if target not in predecessor:
+        return {}
     pred = predecessor[target]
     while pred != "start":
         pred_elab[target.split("_")[0]] = pred
         target = pred
+        if target not in predecessor:
+            return {}
         pred = predecessor[target]
     return pred_elab


### PR DESCRIPTION
The coupling issue arises in the viterbi_search function due to its reliance on the get_predecessor function. One concern with this coupling is within the get_predecessor function, where a key is retrieved from a dictionary using the get operation. The key might not always exist in the dictionary, but I've implemented a check in get_predecessor to ensure the program won't crash if attempting to get a non-existent key. In such cases, get_predecessor will return an empty dictionary.

I've also added comments in the viterbi_search function to emphasize that get_predecessor should be used separately. Additionally, it's crucial to verify whether the returned predecessor is empty after calling get_predecessor.